### PR TITLE
Handle user model w/o username field

### DIFF
--- a/django_google_sso/main.py
+++ b/django_google_sso/main.py
@@ -100,10 +100,13 @@ class UserHelper:
         return email_verified if email_verified is not None else False
 
     def get_or_create_user(self, extra_users_args: dict | None = None):
-        user_model = get_user_model()
+        user_model = get_user_model()g
         user_defaults = extra_users_args or {}
-        if "username" not in user_defaults:
-            user_defaults["username"] = self.user_email
+        try:
+            if "username" not in user_defaults and user_model._meta.get_field("username"):
+                user_defaults["username"] = self.user_email
+        except FieldDoesNotExist:
+            pass
         user, created = user_model.objects.get_or_create(
             email=self.user_email, defaults=user_defaults
         )


### PR DESCRIPTION
Encountered this in a project based upon Django Cookie Cutter, where an option is provided to not include a username on the custom user model. This change avoids trying to pass "username" as a default to the user creation if it is not present, avoiding the error that would otherwise result.

<img width="745" alt="image" src="https://github.com/megalus/django-google-sso/assets/1409332/1891db49-546c-49ff-9e48-a48c6a9a1fc4">
