### PR TITLE
Allow "*" in GOOGLE_SSO_ALLOWABLE_DOMAINS

### DIFF
--- a/django_google_sso/main.py
+++ b/django_google_sso/main.py
@@ -101,9 +101,11 @@ class UserHelper:
     @property
     def email_is_valid(self) -> bool:
         user_email_domain = self.user_email.split("@")[-1]
-        for email_domain in conf.GOOGLE_SSO_ALLOWABLE_DOMAINS:
-            if user_email_domain in email_domain:
-                return True
+        if (
+            "*" in conf.GOOGLE_SSO_ALLOWABLE_DOMAINS
+            or user_email_domain in conf.GOOGLE_SSO_ALLOWABLE_DOMAINS
+        ):
+            return True
         email_verified = self.user_info.get("email_verified", None)
         if email_verified is not None and not email_verified:
             logger.debug(f"Email {self.user_email} is not verified.")

--- a/docs/users.md
+++ b/docs/users.md
@@ -9,6 +9,13 @@ For example, if any user with a gmail account can sign in, you can set:
 GOOGLE_SSO_ALLOWABLE_DOMAINS = ["gmail.com"]
 ```
 
+To allow everyone to register, you can use "*" as the value (but beware the security implications):
+
+```python
+# Use "*" to add all users
+GOOGLE_SSO_ALLOWABLE_DOMAINS = ["*"]
+```
+
 ## Disabling the auto-create users
 
 You can disable the auto-create users feature by setting the `GOOGLE_SSO_AUTO_CREATE_USERS` setting to `False`:


### PR DESCRIPTION
### Contains
- [ ] Breaking Changes
- [ ] New/Update documentation
- [ ] CI/CD modifications

### Changes
* Allows `"*"` in `GOOGLE_SSO_ALLOWABLE_DOMAINS`
* Fixes `GOOGLE_SSO_ALLOWABLE_DOMAINS` check

### Resolves
The current implementation has a minor security flaw: when `GOOGLE_SSO_ALLOWABLE_DOMAINS` is set to `["gmail.com"]`, not only users from `gmail.com` are allowed, but users from domains `mail.com`, `ail.com`, `il.com`, `l.com`, `gmail.co`, `mail.co`, `ail.co`, `il.co` and `l.co` too. This is caused by checking `user_email_domain in email_domain` instead of `user_email_domain in conf.GOOGLE_SSO_ALLOWABLE_DOMAINS`.

Also, it would be very helpful to have possibility to allow everybody to log in. For this, I propose to set `GOOGLE_SSO_ALLOWABLE_DOMAINS` to `["*"]`. The behavior is similar to the `GITHUB_SSO_ALLOW_ALL_USERS` setting in [django-github-sso](https://github.com/megalus/django-github-sso).