### PR TITLE
Update prompt docs to describe 4th option (no value)

### DIFF
--- a/docs/how.md
+++ b/docs/how.md
@@ -37,9 +37,10 @@ defined in `GOOGLE_SSO_NEXT_URL` (default: `admin:index`) as a fallback.
 
 The setting `GOOGLE_SSO_AUTHORIZATION_PROMPT` controls the `prompt` parameter sent to Google's OpenID Connect authorization URL. It changes what Google shows to the user during authentication/consent:
 
-- `consent` (default): Always shows the consent screen, even if the user previously granted access to the requested scopes.
-- `select_account`: Always shows the account chooser so the user can switch Google accounts before continuing.
-- `none`: Never shows any UI. If the user is not already signed in to Google or has not granted consent yet, Google will return an error instead of showing screens.
+- `"consent"` (default): Always shows the consent screen, even if the user previously granted access to the requested scopes.
+- `"select_account"`: Always shows the account chooser so the user can switch Google accounts before continuing.
+- `"none"`: Never shows any screen. If the user is not already signed in to Google or has not granted consent yet, Google will return an error instead of showing screens.
+- `None` (or `""`): Only show the relevant screens when they are needed. If the user is only logged in to one google account and that account has already consented, both the account and consent screens are bypassed. If consent hasn't been given, or the user is signed in to multiple google accounts, the relevant screens are shown. This is the default google prompt behavior.
 
 Notes when testing locally:
 - If you have already granted consent to the default scopes (`openid`, `userinfo.email`, `userinfo.profile`) for your app, Google may only show the account selection step. This can make it seem like the experience is always the same.


### PR DESCRIPTION
Shout out to @rkday-pro for adding this feature! And to @chrismaille for getting it merged in fast 🤝

### Contains
- [ ] Breaking Changes
- [X] New/Update documentation
- [ ] CI/CD modifications

### Changes
Add text in the docs to describe behavior of supplying `None` (or `""`) for `GOOGLE_SSO_AUTHORIZATION_PROMPT`.
Supplying no value for the `prompt` argument allows for the default google prompt behavior. [Per the google docs](https://developers.google.com/identity/openid-connect/openid-connect#prompt): `If no value is specified and the user has not previously authorized access, then the user is shown a consent screen.`
But if the user is only logged in to one google account and that account has already consented, both screens are bypassed and the user is logged in with just one click (ideal).

I wasn't sure how best to phrase this new option in the doc. Since `none` is a valid option, I thought it'd be a little unclear to put both `none` and `None` in the docs, with the latter being the python None type (no quotes). To make it more clear, I added quotes to the existing options and no quotes for python `None` type. You can also achieve this new option with empty quotes `""`, so I added that note as well. Let me know if you'd prefer different language.
