### PR TITLE
Respect CustomUser.EMAIL_FIELD

### DIFF
--- a/django_google_sso/models.py
+++ b/django_google_sso/models.py
@@ -23,7 +23,8 @@ class GoogleSSOUser(models.Model):
         return None
 
     def __str__(self):
-        return f"{self.user.email} ({self.google_id})"
+        user_email = getattr(self.user, self.user.EMAIL_FIELD)
+        return f"{user_email} ({self.google_id})"
 
     class Meta:
         db_table = "google_sso_user"


### PR DESCRIPTION
### Contains

- [ ] Breaking Changes
- [ ] New/Update documentation
- [ ] CI/CD modifications

### Changes

*  Add support for `CustomUser.EMAIL_FIELD`

A project that I'm working on uses [CustomUser.EMAIL_FIELD](https://docs.djangoproject.com/en/5.2/topics/auth/customizing/#django.contrib.auth.models.CustomUser.EMAIL_FIELD) to customize the column used by django to lookup the email of a user. Doing so breaks django-google-sso as the code currently assumes that `User.email` is always the actual email field. This PR fixes the issues by making the email field lookup dynamic.
